### PR TITLE
Logo: embed base64 PNG + cert/crash hardening (on section_update base)

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,32 @@ const ws = require('ws')
 var bodyParser = require('body-parser');
 const fs = require('fs');
 var rs = require('jsrsasign');
+const path = require('path');
+
+// Read a bundled runtime file (cert/key) from the pkg snapshot first
+// (path.join(__dirname,...) = the /snapshot virtual FS where pkg `assets` live),
+// then next to the exe, then cwd. A bare relative path reads cwd, NOT the
+// snapshot, so a self-contained exe fails with ENOENT — this fixes that.
+function readAppFile(name) {
+    const candidates = [path.join(__dirname, name)];
+    if (process.pkg) candidates.push(path.join(path.dirname(process.execPath), name));
+    candidates.push(name);
+    let lastErr;
+    for (const p of candidates) {
+        try { return fs.readFileSync(p, 'utf8'); } catch (e) { lastErr = e; }
+    }
+    throw lastErr;
+}
+
+// Node 18 terminates the process on an unhandled promise rejection. Print
+// routes do `await qz.*` without try/catch, so a QZ Tray hiccup or bad payload
+// would otherwise CRASH the service ("the EXE closes"). Log and stay up.
+process.on('unhandledRejection', (reason) => {
+    console.error('[unhandledRejection]', (reason && reason.message) || reason);
+});
+process.on('uncaughtException', (err) => {
+    console.error('[uncaughtException]', (err && err.message) || err);
+});
 
 
 const app = express();
@@ -171,7 +197,17 @@ app.post("/generic", async (req, res) => {
 
     let sectionLength = finalData.length - 4;
 
-    showLogo = printData.logoInfo.showLogo && printData.logoInfo.imageUrl != null;
+    // Prefer the embedded base64 PNG: QZ Tray (Java ImageIO) can't decode WebP,
+    // and the logo is stored/served as WebP, so the URL fails. Treat null/''/the
+    // string "null" (sent when no receipt image is configured) as "no logo" so
+    // QZ never gets (FILE)null -> "no protocol: null", which would fail the whole
+    // receipt.
+    const _b64 = printData.logoInfo.imageBase64;
+    const _url = printData.logoInfo.imageUrl;
+    const hasLogoBase64 = typeof _b64 === 'string' && _b64.length > 0;
+    const hasLogoUrl = typeof _url === 'string'
+        && _url.trim() !== '' && _url.trim().toLowerCase() !== 'null';
+    showLogo = printData.logoInfo.showLogo && (hasLogoBase64 || hasLogoUrl);
     isLogoBottom = printData.logoInfo.isBottom;
     if (showLogo) {
         logoPosition = 1
@@ -182,8 +218,8 @@ app.post("/generic", async (req, res) => {
         imagePrint = {
             type: 'raw',
             format: 'image',
-            flavor: 'file',
-            data: printData.logoInfo.imageUrl, //'https://s3.ap-south-1.amazonaws.com/qbstore/chain2024/10000_843159282_1716532886.webp',
+            flavor: hasLogoBase64 ? 'base64' : 'file',
+            data: hasLogoBase64 ? _b64 : _url,
             options: { language: "ESCPOS", dotDensity: 'double' }
         }
 
@@ -310,8 +346,8 @@ function getBarcode(code) {
 
 async function connectPrinter() {
 
-    const privateKey = fs.readFileSync('private-key.pem', 'utf8');
-    const digitalCertificate = fs.readFileSync('digital-certificate.txt', "utf8");
+    const privateKey = readAppFile('private-key.pem');
+    const digitalCertificate = readAppFile('digital-certificate.txt');
 
     qz.security.setCertificatePromise(function (resolve, reject) {
         resolve(digitalCertificate);

--- a/index.js
+++ b/index.js
@@ -220,7 +220,14 @@ app.post("/generic", async (req, res) => {
             format: 'image',
             flavor: hasLogoBase64 ? 'base64' : 'file',
             data: hasLogoBase64 ? _b64 : _url,
-            options: { language: "ESCPOS", dotDensity: 'double' }
+            // align:'center' tells QZ Tray to pad the raster client-side so the
+            // image is centered on the paper before sending to the printer.
+            // Most cheap ESC/POS thermals (Rugtek included) honour `ESC a 1`
+            // for text but ignore it for raster bitmaps — without this option
+            // a narrower-than-paper logo prints flush left. QZ asks the printer
+            // for its width and pads accordingly, so this works for both 58mm
+            // and 80mm rolls.
+            options: { language: "ESCPOS", dotDensity: 'double', align: 'center' }
         }
 
         if (!printData.logoInfo.isBottom) {

--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,80 @@
+# QBPrinter — Windows Service install
+
+These scripts register `printer.exe` (the QueueBuster QZ Tray print bridge) as
+a real Windows Service so it:
+
+- runs hidden in the background — no console window
+- starts automatically at boot
+- survives user logoff
+- **cannot be closed by a non-admin user** via Task Manager
+- auto-restarts within 3 seconds if it ever crashes
+
+This is the recommended production deployment. Replaces the "double-click the
+exe and leave the window open" workflow that merchants kept closing.
+
+## What you need (3 files, all in the same folder)
+
+| File | Where to get it |
+|---|---|
+| `printer.exe` | from this repo (`npx pkg . --targets node18-win-x64 --output printer.exe`) |
+| `nssm.exe` | https://nssm.cc/download — pick `win64\nssm.exe` from the latest release zip (~340 KB, MIT-licensed) |
+| `install-service.bat` / `uninstall-service.bat` | this folder |
+
+Put all four in one directory on the merchant's machine, e.g.
+`C:\Program Files\QBPrinter\`.
+
+## Install
+
+1. Right-click `install-service.bat` → **Run as administrator**
+   (or the script will self-elevate via UAC prompt).
+2. Wait for "QBPrinter installed and started" message.
+3. Done — the service is running and will auto-start on every boot.
+
+## Verify
+
+```cmd
+sc query QBPrinter
+```
+should show `STATE : 4 RUNNING`.
+
+Or open `services.msc` and look for **QBPrinter**.
+
+Test a print from the merchant's POS — it should work without the merchant
+ever having to launch a window.
+
+## Logs
+
+The service logs stdout/stderr to:
+- `C:\ProgramData\QBPrinter\out.log`
+- `C:\ProgramData\QBPrinter\err.log`
+
+Both rotate at 10 MB.
+
+## Common operations (admin cmd)
+
+| Action | Command |
+|---|---|
+| Stop | `sc stop QBPrinter` |
+| Start | `sc start QBPrinter` |
+| Restart | `sc stop QBPrinter && sc start QBPrinter` |
+| Uninstall | run `uninstall-service.bat` as admin |
+| Reinstall (upgrade) | drop a new `printer.exe`, re-run `install-service.bat` (it cleans up the prior install first) |
+
+## Troubleshooting
+
+- **"QZ Tray not connected"** in `err.log` — QZ Tray itself must be installed
+  and running. The QBPrinter service connects to QZ Tray over WebSocket on
+  localhost; it does **not** include QZ Tray.
+- **Printer not found / wrong printer** — Windows services run as `LocalSystem`
+  by default, which sometimes can't see printers installed under a specific
+  user account. If this happens, configure the service to run as the merchant
+  user from `services.msc` → QBPrinter → Properties → Log On.
+- **Service won't start** — open `err.log`. Most common causes are a missing
+  bundled cert (rebuild `printer.exe`) or QZ Tray being stopped.
+
+## Why a service and not a tray app
+
+A regular hidden console can be killed via Task Manager by any user. A real
+Windows service is protected by the SCM and can only be stopped by an
+administrator. This was the explicit ask from merchants who kept accidentally
+closing the bridge window.

--- a/service/README.md
+++ b/service/README.md
@@ -16,12 +16,12 @@ exe and leave the window open" workflow that merchants kept closing.
 
 | File | Where to get it |
 |---|---|
-| `printer.exe` | from this repo (`npx pkg . --targets node18-win-x64 --output printer.exe`) |
-| `nssm.exe` | https://nssm.cc/download — pick `win64\nssm.exe` from the latest release zip (~340 KB, MIT-licensed) |
+| `printer.exe` | [Drive download](https://drive.google.com/file/d/1SL3wHwy9VthvHW73q1aSiYUKfCmZgF0v/view?usp=sharing) — QueueBuster QZ Tray print bridge (~48 MB) |
+| `nssm.exe` | [Drive download](https://drive.google.com/file/d/1qFMCyb3y8oMqWi-rvPegFcRi3AJP0qiV/view?usp=sharing) — Non-Sucking Service Manager 2.24 win64 (~324 KB, MIT) |
 | `install-service.bat` / `uninstall-service.bat` | this folder |
 
-Put all four in one directory on the merchant's machine, e.g.
-`C:\Program Files\QBPrinter\`.
+Download both exes from the Drive links above. Put all four files in one
+directory on the merchant's machine, e.g. `C:\Program Files\QBPrinter\`.
 
 ## Install
 

--- a/service/README.md
+++ b/service/README.md
@@ -12,16 +12,17 @@ a real Windows Service so it:
 This is the recommended production deployment. Replaces the "double-click the
 exe and leave the window open" workflow that merchants kept closing.
 
-## What you need (3 files, all in the same folder)
+## What you need (4 files, all in the same folder)
 
 | File | Where to get it |
 |---|---|
 | `printer.exe` | [Drive download](https://drive.google.com/file/d/1SL3wHwy9VthvHW73q1aSiYUKfCmZgF0v/view?usp=sharing) — QueueBuster QZ Tray print bridge (~48 MB) |
 | `nssm.exe` | [Drive download](https://drive.google.com/file/d/1qFMCyb3y8oMqWi-rvPegFcRi3AJP0qiV/view?usp=sharing) — Non-Sucking Service Manager 2.24 win64 (~324 KB, MIT) |
-| `install-service.bat` / `uninstall-service.bat` | this folder |
+| `install-service.bat` | [Drive download](https://drive.google.com/file/d/1bdT0xiSVEEk5wVI3VFrIhFRYKsR0CBuq/view?usp=sharing) — installs the Windows service (run as admin) |
+| `uninstall-service.bat` | [Drive download](https://drive.google.com/file/d/1vooa5VhUgkJZ6UryKcGnCifmYsWbSIKT/view?usp=sharing) — removes the service (run as admin) |
 
-Download both exes from the Drive links above. Put all four files in one
-directory on the merchant's machine, e.g. `C:\Program Files\QBPrinter\`.
+Download all four files from the Drive links above. Put them in one directory
+on the merchant's machine, e.g. `C:\Program Files\QBPrinter\`.
 
 ## Install
 

--- a/service/install-service.bat
+++ b/service/install-service.bat
@@ -1,0 +1,118 @@
+@echo off
+REM ============================================================================
+REM QBPrinter — install printer.exe as a hidden, auto-restart Windows Service.
+REM
+REM What this does:
+REM   1. Self-elevates to Administrator (UAC prompt). Required to register a
+REM      service and write to ProgramData.
+REM   2. Stops + removes any prior QBPrinter service so an upgrade is clean.
+REM   3. Registers printer.exe under SERVICE_AUTO_START using NSSM, points its
+REM      logs to C:\ProgramData\QBPrinter\, auto-restarts on crash after 3s.
+REM   4. Starts the service.
+REM
+REM End result: the bridge starts at boot, runs hidden, survives logoff, and a
+REM non-admin user cannot stop or close it via Task Manager.
+REM
+REM Requirements (next to this .bat):
+REM   - nssm.exe       (https://nssm.cc/download, ~340 KB, MIT)
+REM   - printer.exe    (the QZ print bridge)
+REM
+REM Re-running this script reinstalls cleanly (good for upgrades).
+REM ============================================================================
+
+REM ---- self-elevate -----------------------------------------------------------
+net session >nul 2>&1
+if %errorLevel% neq 0 (
+    echo Requesting administrator privileges...
+    powershell -Command "Start-Process '%~f0' -Verb RunAs"
+    exit /b
+)
+
+setlocal
+set "SERVICE_NAME=QBPrinter"
+set "SCRIPT_DIR=%~dp0"
+set "NSSM=%SCRIPT_DIR%nssm.exe"
+set "EXE=%SCRIPT_DIR%printer.exe"
+set "LOG_DIR=C:\ProgramData\QBPrinter"
+set "OUT_LOG=%LOG_DIR%\out.log"
+set "ERR_LOG=%LOG_DIR%\err.log"
+
+REM ---- sanity checks ----------------------------------------------------------
+if not exist "%NSSM%" (
+    echo [FAIL] nssm.exe not found next to this script: "%NSSM%"
+    echo Download from https://nssm.cc/download and place it beside install-service.bat
+    pause
+    exit /b 1
+)
+if not exist "%EXE%" (
+    echo [FAIL] printer.exe not found next to this script: "%EXE%"
+    pause
+    exit /b 1
+)
+
+REM ---- ensure log dir ---------------------------------------------------------
+if not exist "%LOG_DIR%" mkdir "%LOG_DIR%" >nul 2>&1
+
+REM ---- clean any prior install (so this script is also the upgrade path) -----
+sc query "%SERVICE_NAME%" >nul 2>&1
+if %errorLevel% equ 0 (
+    echo Stopping existing %SERVICE_NAME% service...
+    "%NSSM%" stop "%SERVICE_NAME%" >nul 2>&1
+    echo Removing existing %SERVICE_NAME% service...
+    "%NSSM%" remove "%SERVICE_NAME%" confirm >nul 2>&1
+)
+
+REM ---- install + configure ----------------------------------------------------
+echo Installing %SERVICE_NAME% service...
+"%NSSM%" install "%SERVICE_NAME%" "%EXE%"
+if %errorLevel% neq 0 (
+    echo [FAIL] nssm install returned errorlevel %errorLevel%
+    pause
+    exit /b 1
+)
+
+REM Start at boot.
+"%NSSM%" set "%SERVICE_NAME%" Start SERVICE_AUTO_START
+
+REM Working dir = the folder containing printer.exe. This matters because the
+REM bridge reads bundled assets relative to its own location (see readAppFile).
+"%NSSM%" set "%SERVICE_NAME%" AppDirectory "%SCRIPT_DIR%"
+
+REM Log stdout/stderr to a stable location for support.
+"%NSSM%" set "%SERVICE_NAME%" AppStdout "%OUT_LOG%"
+"%NSSM%" set "%SERVICE_NAME%" AppStderr "%ERR_LOG%"
+
+REM Rotate logs at 10 MB so they don't grow without bound.
+"%NSSM%" set "%SERVICE_NAME%" AppRotateFiles 1
+"%NSSM%" set "%SERVICE_NAME%" AppRotateOnline 1
+"%NSSM%" set "%SERVICE_NAME%" AppRotateBytes 10485760
+
+REM Auto-restart 3s after any exit; cap restart loop so we don't spin if it's
+REM truly broken (10 restarts then back-off).
+"%NSSM%" set "%SERVICE_NAME%" AppExit Default Restart
+"%NSSM%" set "%SERVICE_NAME%" AppRestartDelay 3000
+"%NSSM%" set "%SERVICE_NAME%" AppThrottle 1500
+
+REM Human-readable description in services.msc.
+"%NSSM%" set "%SERVICE_NAME%" Description "QueueBuster QZ Tray print bridge. Auto-starts on boot, restarts on crash."
+
+REM ---- start ------------------------------------------------------------------
+echo Starting %SERVICE_NAME%...
+"%NSSM%" start "%SERVICE_NAME%"
+if %errorLevel% neq 0 (
+    echo [WARN] start returned errorlevel %errorLevel% — check %ERR_LOG%
+    pause
+    exit /b 1
+)
+
+echo.
+echo ============================================================================
+echo  %SERVICE_NAME% installed and started.
+echo    Logs:  %OUT_LOG%
+echo           %ERR_LOG%
+echo    Stop/start:  services.msc  (search %SERVICE_NAME%)
+echo    Or admin cmd: sc stop %SERVICE_NAME%  /  sc start %SERVICE_NAME%
+echo ============================================================================
+echo.
+pause
+endlocal

--- a/service/uninstall-service.bat
+++ b/service/uninstall-service.bat
@@ -1,0 +1,44 @@
+@echo off
+REM ============================================================================
+REM QBPrinter — uninstall the printer.exe Windows Service.
+REM
+REM Self-elevates to Administrator (UAC prompt). Stops the service, removes
+REM the registration. Leaves printer.exe / certs / logs on disk untouched so
+REM support can still inspect %LOG_DIR%\err.log after removal.
+REM ============================================================================
+
+net session >nul 2>&1
+if %errorLevel% neq 0 (
+    echo Requesting administrator privileges...
+    powershell -Command "Start-Process '%~f0' -Verb RunAs"
+    exit /b
+)
+
+setlocal
+set "SERVICE_NAME=QBPrinter"
+set "SCRIPT_DIR=%~dp0"
+set "NSSM=%SCRIPT_DIR%nssm.exe"
+
+sc query "%SERVICE_NAME%" >nul 2>&1
+if %errorLevel% neq 0 (
+    echo %SERVICE_NAME% is not installed. Nothing to do.
+    pause
+    exit /b 0
+)
+
+if exist "%NSSM%" (
+    echo Stopping %SERVICE_NAME%...
+    "%NSSM%" stop "%SERVICE_NAME%" >nul 2>&1
+    echo Removing %SERVICE_NAME%...
+    "%NSSM%" remove "%SERVICE_NAME%" confirm
+) else (
+    REM Fallback if nssm.exe is missing — use sc directly.
+    echo nssm.exe not found, falling back to sc...
+    sc stop   "%SERVICE_NAME%" >nul 2>&1
+    sc delete "%SERVICE_NAME%"
+)
+
+echo.
+echo %SERVICE_NAME% removed. Logs preserved at C:\ProgramData\QBPrinter\.
+pause
+endlocal


### PR DESCRIPTION
## Summary
- Logo: prefer `logoInfo.imageBase64` (PNG) over `imageUrl`. QZ Tray (Java ImageIO) can't decode WebP, and the receipt logo is stored/served as WebP, so URL-based prints fail. Treat `null`/`''`/the string `"null"` as "no logo" (used to crash the whole receipt with `no protocol: null`).
- Cert read via `readAppFile` (pkg `__dirname` snapshot) so the bundled exe is self-contained — no ENOENT.
- `unhandledRejection` / `uncaughtException` handlers (Node 18 auto-close guard).

Companion app change: `QZConfig.LogoInfo.imageBase64` field; `QzPrintBuilder` downscales the locally-decoded logo to ≤200px and PNG-encodes it.

## Backward-compatible
| App ↓ / Bridge → | New bridge |
|---|---|
| Old app (URL only) | URL via `flavor:'file'` — unchanged |
| New app (base64) | PNG base64 — WebP fixed |
| Any app, `"null"` URL | logo skipped, receipt prints — was a crash |

Based on `section_update` (the branch matching the current app payload: `section.data` + `dataType`).

## Test plan
- [ ] Install exe + APK with the QZConfig change, print a WebP-logo merchant -> logo prints
- [ ] Old app + new exe still prints PNG-URL logos
- [ ] Merchant with no logo (`imageUrl="null"`) prints the rest of the receipt
- [ ] QR / barcode / text sections still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)